### PR TITLE
There is RestClient::make_request, but no way to use the result

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -470,7 +470,7 @@ impl RestClient {
         Ok(())
     }
 
-    fn run_request(&mut self, req: hyper::Request<hyper::Body>) -> Result<String, Error> {
+    pub fn run_request(&mut self, req: hyper::Request<hyper::Body>) -> Result<String, Error> {
         debug!("{} {}", req.method(), req.uri());
         trace!("{:?}", req);
 


### PR DESCRIPTION
[`RestClient::make_request`](https://docs.rs/restson/0.5.1/restson/struct.RestClient.html#method.make_request) is a public but undocumented function to create a [`http::request::Request`](https://docs.rs/http/0.1.14/http/request/struct.Request.html), but as far as I can see there is no convenient way to use that `Request`.

Is it a stupid idea to make [`RestClient::run_request`](https://docs.rs/restson/0.5.1/src/restson/lib.rs.html#473) public?