### PR TITLE
Builder pattern: Consume `self` instead of taking mutable references

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,7 +181,7 @@ impl Builder {
     ///
     /// Default is 4
     #[inline]
-    pub fn dns_workers(&mut self, workers: usize) -> &mut Self {
+    pub fn dns_workers(mut self, workers: usize) -> Self {
         self.dns_workers = workers;
         self
     }
@@ -190,7 +190,7 @@ impl Builder {
     ///
     /// Default is no timeout
     #[inline]
-    pub fn timeout(&mut self, timeout: Duration) -> &mut Self {
+    pub fn timeout(mut self, timeout: Duration) -> Self {
         self.timeout = timeout;
         self
     }
@@ -199,13 +199,13 @@ impl Builder {
     ///
     /// Default is yes
     #[inline]
-    pub fn send_null_body(&mut self, value: bool) -> &mut Self {
+    pub fn send_null_body(mut self, value: bool) -> Self {
         self.send_null_body = value;
         self
     }
 
     /// Create `RestClient` with the configuration in this builder
-    pub fn build(&self, url: &str) -> Result<RestClient, Error> {
+    pub fn build(self, url: &str) -> Result<RestClient, Error> {
         RestClient::with_builder(url, self)
     }
 }
@@ -227,10 +227,10 @@ impl RestClient {
     ///
     /// Use `Builder` to configure the client.
     pub fn new(url: &str) -> Result<RestClient, Error> {
-        RestClient::with_builder(url, &RestClient::builder())
+        RestClient::with_builder(url, RestClient::builder())
     }
 
-    fn with_builder(url: &str, builder: &Builder) -> Result<RestClient, Error> {
+    fn with_builder(url: &str, builder: Builder) -> Result<RestClient, Error> {
         let core = tokio_core::reactor::Core::new().map_err(|_| Error::HttpClientError)?;
 
         let https = HttpsConnector::new(builder.dns_workers).map_err(|_| Error::HttpClientError)?;


### PR DESCRIPTION
The builder pattern used for `Builder` type uses mutable references to modify itself and `RestClient::with_builder()` to consumes the builder.

This PR changes this to consumes `self` instead.

While this shouldn't change much here, it allows a further modifications (PR to be opened) where I want to be able to provide my own `hyper::client`. I would do so by adding a `Builder::with_client(mut self, client: HyperClient) -> Self` method and match on the `Option<HyperClient>`. This cannot be done if the builder passed to `RestClient::with_builder()` takes a reference to the builder (as I can't extract the client from the reference...)

Since the builder methods take a mutable reference, the [`get()` test](https://github.com/spietika/restson-rust/blob/master/tests/get.rs#L52-L57) cannot be built anymore since the last builder method used ([`send_null_body()`](https://github.com/spietika/restson-rust/blob/master/tests/get.rs#L55)) returns a reference and not an owned value.

Hope my explanation is clear enough... 🤔 