### PR TITLE
Add client to builder

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,7 +181,7 @@ impl Builder {
     ///
     /// Default is 4
     #[inline]
-    pub fn dns_workers(&mut self, workers: usize) -> &mut Self {
+    pub fn dns_workers(mut self, workers: usize) -> Self {
         self.dns_workers = workers;
         self
     }
@@ -190,7 +190,7 @@ impl Builder {
     ///
     /// Default is no timeout
     #[inline]
-    pub fn timeout(&mut self, timeout: Duration) -> &mut Self {
+    pub fn timeout(mut self, timeout: Duration) -> Self {
         self.timeout = timeout;
         self
     }
@@ -199,13 +199,13 @@ impl Builder {
     ///
     /// Default is yes
     #[inline]
-    pub fn send_null_body(&mut self, value: bool) -> &mut Self {
+    pub fn send_null_body(mut self, value: bool) -> Self {
         self.send_null_body = value;
         self
     }
 
     /// Create `RestClient` with the configuration in this builder
-    pub fn build(&self, url: &str) -> Result<RestClient, Error> {
+    pub fn build(self, url: &str) -> Result<RestClient, Error> {
         RestClient::with_builder(url, self)
     }
 }
@@ -227,10 +227,10 @@ impl RestClient {
     ///
     /// Use `Builder` to configure the client.
     pub fn new(url: &str) -> Result<RestClient, Error> {
-        RestClient::with_builder(url, &RestClient::builder())
+        RestClient::with_builder(url, RestClient::builder())
     }
 
-    fn with_builder(url: &str, builder: &Builder) -> Result<RestClient, Error> {
+    fn with_builder(url: &str, builder: Builder) -> Result<RestClient, Error> {
         let core = tokio_core::reactor::Core::new().map_err(|_| Error::HttpClientError)?;
 
         let https = HttpsConnector::new(builder.dns_workers).map_err(|_| Error::HttpClientError)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,10 +72,12 @@ static VERSION: &'static str = env!("CARGO_PKG_VERSION");
 /// would be parsed to **param1=1234&param2=abcd** in the request URL.
 pub type Query<'a> = [(&'a str, &'a str)];
 
+pub type HyperClient = Client<HttpsConnector<hyper::client::HttpConnector>>;
+
 /// REST client to make HTTP GET and POST requests.
 pub struct RestClient {
     core: tokio_core::reactor::Core,
-    client: Client<HttpsConnector<hyper::client::HttpConnector>>,
+    client: HyperClient,
     baseurl: url::Url,
     auth: Option<String>,
     headers: HeaderMap,


### PR DESCRIPTION
This PR gives user the possibility to provide their own `client` to use (`Client<HttpsConnector<hyper::client::HttpConnector>>`).

Note that this PR includes commit af3bafbca26fc3871af8e0f39728ccbdc141ca64 added in PR #18.

I need to provide my own client so that can modify TLS/SSL options. I need to:
1. Trust a specific self-signed certificate: The REST server (not under my control) is using a self-signed certificate. I need to be able to trust this one from the code (not from the OS).
2. I connect to the server through its IP, not through its hostname, which requires another option to the TLS config (since the certificate is self-signed for the hostname, not the ip)

Here's how I setup my `client` so that it accepts the self-signed certificate:

```rust
let dns_workers = 4;
let mut http = hyper::client::HttpConnector::new(dns_workers);
http.enforce_http(false);

let mut tls_connector_builder = native_tls::TlsConnector::builder();

// Read the certificate to a slice of bytes
const SELF_SIGNED_CERT: &[u8] = include_bytes!("/path/to/certificate.crt");

// Create a `native_tls::Certificate`
let certificate = native_tls::Certificate::from_pem(SELF_SIGNED_CERT).unwrap();

// Adds the certificate to the set of roots that the connector will trust.
// See https://docs.rs/native-tls/0.2.2/native_tls/struct.TlsConnectorBuilder.html#method.add_root_certificate
tls_connector_builder.add_root_certificate(certificate);

// Disable host name verification
// See https://docs.rs/native-tls/0.2.2/native_tls/struct.TlsConnectorBuilder.html#method.danger_accept_invalid_hostnames
tls_connector_builder.danger_accept_invalid_hostnames(true);

// // Accept all certificates, even if invalid
// // See https://docs.rs/native-tls/0.2.2/native_tls/struct.TlsConnectorBuilder.html#method.danger_accept_invalid_certs
// tls_connector_builder.danger_accept_invalid_certs(true);

let tls_connector = tls_connector_builder.build().unwrap();
let https = hyper_tls::HttpsConnector::<hyper::client::HttpConnector>::from((http, tls_connector));

// Build the hyper client
let client = hyper::Client::builder().build(https);

// Build the restson::Client
let client = restson::Builder::default()
    .send_null_body(false)
    .with_client(client)
    .timeout(std::time::Duration::from_secs(5))
    .build(server.as_ref())?;
```

Dependencies:
```toml
hyper = "^0.12.14"
hyper-tls = "^0.3.1"
native-tls = "^0.2"
```