### PR TITLE
make_uri: Use join rather than set_path

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -593,8 +593,9 @@ impl RestClient {
     }
 
     fn make_uri(&self, path: &str, params: Option<&Query>) -> Result<hyper::Uri, Error> {
-        let mut url = self.baseurl.clone();
-        url.set_path(path);
+        let mut url = self.baseurl.clone()
+            .join(path)
+            .map_err(|_| Error::UrlError)?;
 
         if let Some(params) = params {
             for &(key, item) in params.iter() {


### PR DESCRIPTION
This allows the path of the `base_uri` to be kept, and to use the full power of the join function (like relative paths, etc).

That is useful if an API moves, changes subpath, etc. E.g. if the api goes from `/` to `/v1`.

## Example

```rust
#[derive(Debug, Deserialize)]
struct HttpBinAnything {
    method: String,
    url: String,
}

impl RestPath<u32> for HttpBinAnything {
    fn get_path(param: u32) -> Result<String, Error> {
        Ok(format!("{}", param))
    }
}

fn main() -> Result<(), Error> {
    let mut client = RestClient::new("http://httpbin.org/anything/")?;
    // Will query http://httpbin.org/anything/42
    println!("{:?}", client.get::<u32, HttpBinAnything>(42)?);
}
```