### PR TITLE
Make client Async by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,11 @@ license = "MIT"
 edition = "2018"
 
 [dependencies]
-hyper = "^0.13.2"
+hyper = { version = "^0.13.2", default-features = false }
 hyper-tls = "^0.4.1"
-futures = "^0.3"
-tokio = { version = "^0.2", features = ["full"] }
+tokio = { version = "^0.2", features = ["time"] }
 serde = "^1.0"
 serde_json = "^1.0"
-serde_derive = "1.0"
 url = "2"
 log = "^0.4.6"
-base64 = "0.11"
+base64 = "0.13"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,10 @@ url = "2"
 log = "^0.4.6"
 base64 = "0.13"
 
+[dev-dependencies]
+serde_derive = "^1.0"
+tokio = { version = "^0.2", features = ["macros"] }
+
 [features]
 default = []
 blocking = ["tokio/macros"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,7 @@ serde_json = "^1.0"
 url = "2"
 log = "^0.4.6"
 base64 = "0.13"
+
+[features]
+default = []
+blocking = ["tokio/macros"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,5 +25,5 @@ serde_derive = "^1.0"
 tokio = { version = "^0.2", features = ["macros"] }
 
 [features]
-default = []
+default = ["blocking"]
 blocking = ["tokio/macros"]

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -1,0 +1,202 @@
+//! Blocking variant of the `RestClient`
+
+use crate::{Error, Query, RestClient as AsyncRestClient, RestPath};
+use hyper::header::{HeaderMap, HeaderValue};
+use std::time::Duration;
+
+/// REST client to make HTTP GET and POST requests. Blocking version.
+pub struct RestClient {
+    inner_client: AsyncRestClient,
+}
+
+impl From<AsyncRestClient> for RestClient {
+    fn from(other: AsyncRestClient) -> Self {
+        Self { inner_client: other }
+    }
+}
+
+impl RestClient {
+    /// Set whether a message body consisting only 'null' (from serde serialization)
+    /// is sent in POST/PUT
+    pub fn set_send_null_body(&mut self, send_null: bool) {
+        self.inner_client.send_null_body = send_null;
+    }
+
+    /// Set credentials for HTTP Basic authentication.
+    pub fn set_auth(&mut self, user: &str, pass: &str) {
+        let mut s: String = user.to_owned();
+        s.push_str(":");
+        s.push_str(pass);
+        self.inner_client.auth = Some("Basic ".to_owned() + &base64::encode(&s));
+    }
+
+    /// Set a function that cleans the response body up before deserializing it.
+    pub fn set_body_wash_fn(&mut self, func: fn(String) -> String) {
+        self.inner_client.body_wash_fn = func;
+    }
+
+    /// Set request timeout
+    pub fn set_timeout(&mut self, timeout: Duration) {
+        self.inner_client.timeout = timeout;
+    }
+
+    /// Set HTTP header from string name and value.
+    ///
+    /// The header is added to all subsequent GET and POST requests
+    /// unless the headers are cleared with `clear_headers()` call.
+    pub fn set_header(&mut self, name: &'static str, value: &str) -> Result<(), Error> {
+        let value = HeaderValue::from_str(value).map_err(|_| Error::InvalidValue)?;
+        self.inner_client.headers.insert(name, value);
+        Ok(())
+    }
+
+    /// Clear all previously set headers
+    pub fn clear_headers(&mut self) {
+        self.inner_client.headers.clear();
+    }
+
+    /// Response headers captured from previous request
+    pub fn response_headers(&mut self) -> &HeaderMap {
+        &self.inner_client.response_headers
+    }
+
+    /// Make a GET request.
+    #[tokio::main]
+    pub async fn get<U, T>(&mut self, params: U) -> Result<T, Error>
+    where
+        T: serde::de::DeserializeOwned + RestPath<U>,
+    {
+        self.inner_client.get(params).await
+    }
+
+    /// Make a GET request with query parameters.
+    #[tokio::main]
+    pub async fn get_with<U, T>(&mut self, params: U, query: &Query<'_>) -> Result<T, Error>
+    where
+        T: serde::de::DeserializeOwned + RestPath<U>,
+    {
+        self.inner_client.get_with(params, query).await
+    }
+
+    /// Make a POST request.
+    #[tokio::main]
+    pub async fn post<U, T>(&mut self, params: U, data: &T) -> Result<(), Error>
+    where
+        T: serde::Serialize + RestPath<U>,
+    {
+        self.inner_client.post(params, data).await
+    }
+
+    /// Make a PUT request.
+    #[tokio::main]
+    pub async fn put<U, T>(&mut self, params: U, data: &T) -> Result<(), Error>
+    where
+        T: serde::Serialize + RestPath<U>,
+    {
+        self.inner_client.put(params, data).await
+    }
+
+    /// Make a PATCH request.
+    #[tokio::main]
+    pub async fn patch<U, T>(&mut self, params: U, data: &T) -> Result<(), Error>
+    where
+        T: serde::Serialize + RestPath<U>,
+    {
+        self.inner_client.patch(params, data).await
+    }
+
+    /// Make POST request with query parameters.
+    #[tokio::main]
+    pub async fn post_with<U, T>(&mut self, params: U, data: &T, query: &Query<'_>) -> Result<(), Error>
+    where
+        T: serde::Serialize + RestPath<U>,
+    {
+        self.inner_client.post_with(params, data, query).await
+    }
+
+    /// Make PUT request with query parameters.
+    #[tokio::main]
+    pub async fn put_with<U, T>(&mut self, params: U, data: &T, query: &Query<'_>) -> Result<(), Error>
+    where
+        T: serde::Serialize + RestPath<U>,
+    {
+        self.inner_client.put_with(params, data, query).await
+    }
+
+    /// Make PATCH request with query parameters.
+    #[tokio::main]
+    pub async fn patch_with<U, T>(&mut self, params: U, data: &T, query: &Query<'_>) -> Result<(), Error>
+    where
+        T: serde::Serialize + RestPath<U>,
+    {
+        self.inner_client.patch_with(params, data, query).await
+    }
+
+    /// Make a POST request and capture returned body.
+    #[tokio::main]
+    pub async fn post_capture<U, T, K>(&mut self, params: U, data: &T) -> Result<K, Error>
+    where
+        T: serde::Serialize + RestPath<U>,
+        K: serde::de::DeserializeOwned,
+    {
+        self.inner_client.post_capture(params, data).await
+    }
+
+    /// Make a PUT request and capture returned body.
+    #[tokio::main]
+    pub async fn put_capture<U, T, K>(&mut self, params: U, data: &T) -> Result<K, Error>
+    where
+        T: serde::Serialize + RestPath<U>,
+        K: serde::de::DeserializeOwned,
+    {
+        self.inner_client.put_capture(params, data).await
+    }
+
+    /// Make a POST request with query parameters and capture returned body.
+    #[tokio::main]
+    pub async fn post_capture_with<U, T, K>(
+        &mut self,
+        params: U,
+        data: &T,
+        query: &Query<'_>,
+    ) -> Result<K, Error>
+    where
+        T: serde::Serialize + RestPath<U>,
+        K: serde::de::DeserializeOwned,
+    {
+        self.inner_client.post_capture_with(params, data, query).await
+    }
+
+    /// Make a PUT request with query parameters and capture returned body.
+    #[tokio::main]
+    pub async fn put_capture_with<U, T, K>(
+        &mut self,
+        params: U,
+        data: &T,
+        query: &Query<'_>,
+    ) -> Result<K, Error>
+    where
+        T: serde::Serialize + RestPath<U>,
+        K: serde::de::DeserializeOwned,
+    {
+        self.inner_client.put_capture_with(params, data, query).await
+    }
+
+    /// Make a DELETE request.
+    #[tokio::main]
+    pub async fn delete<U, T>(&mut self, params: U) -> Result<(), Error>
+    where
+        T: RestPath<U>,
+    {
+        self.inner_client.delete::<U, T>(params).await
+    }
+
+    /// Make a DELETE request with query and body.
+    #[tokio::main]
+    pub async fn delete_with<U, T>(&mut self, params: U, data: &T, query: &Query<'_>) -> Result<(), Error>
+    where
+        T: serde::Serialize + RestPath<U>,
+    {
+        self.inner_client.delete_with(params, data, query).await
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -299,92 +299,92 @@ impl RestClient {
     }
 
     /// Make a GET request.
-    pub fn get<U, T>(&mut self, params: U) -> Result<T, Error>
+    pub async fn get<U, T>(&mut self, params: U) -> Result<T, Error>
     where
         T: serde::de::DeserializeOwned + RestPath<U>,
     {
         let req = self.make_request::<U, T>(Method::GET, params, None, None)?;
-        let body = self.run_request(req)?;
+        let body = self.run_request(req).await?;
 
         serde_json::from_str(body.as_str()).map_err(|err| Error::DeserializeParseError(err, body))
     }
 
     /// Make a GET request with query parameters.
-    pub fn get_with<U, T>(&mut self, params: U, query: &Query) -> Result<T, Error>
+    pub async fn get_with<U, T>(&mut self, params: U, query: &Query<'_>) -> Result<T, Error>
     where
         T: serde::de::DeserializeOwned + RestPath<U>,
     {
         let req = self.make_request::<U, T>(Method::GET, params, Some(query), None)?;
-        let body = self.run_request(req)?;
+        let body = self.run_request(req).await?;
 
         serde_json::from_str(body.as_str()).map_err(|err| Error::DeserializeParseError(err, body))
     }
 
     /// Make a POST request.
-    pub fn post<U, T>(&mut self, params: U, data: &T) -> Result<(), Error>
+    pub async fn post<U, T>(&mut self, params: U, data: &T) -> Result<(), Error>
     where
         T: serde::Serialize + RestPath<U>,
     {
-        self.post_or_put(Method::POST, params, data)
+        self.post_or_put(Method::POST, params, data).await
     }
 
     /// Make a PUT request.
-    pub fn put<U, T>(&mut self, params: U, data: &T) -> Result<(), Error>
+    pub async fn put<U, T>(&mut self, params: U, data: &T) -> Result<(), Error>
     where
         T: serde::Serialize + RestPath<U>,
     {
-        self.post_or_put(Method::PUT, params, data)
+        self.post_or_put(Method::PUT, params, data).await
     }
 
     /// Make a PATCH request.
-    pub fn patch<U, T>(&mut self, params: U, data: &T) -> Result<(), Error>
+    pub async fn patch<U, T>(&mut self, params: U, data: &T) -> Result<(), Error>
     where
         T: serde::Serialize + RestPath<U>,
     {
-        self.post_or_put(Method::PATCH, params, data)
+        self.post_or_put(Method::PATCH, params, data).await
     }
 
-    fn post_or_put<U, T>(&mut self, method: Method, params: U, data: &T) -> Result<(), Error>
+    async fn post_or_put<U, T>(&mut self, method: Method, params: U, data: &T) -> Result<(), Error>
     where
         T: serde::Serialize + RestPath<U>,
     {
         let data = serde_json::to_string(data).map_err(Error::SerializeParseError)?;
 
         let req = self.make_request::<U, T>(method, params, None, Some(data))?;
-        self.run_request(req)?;
+        self.run_request(req).await?;
         Ok(())
     }
 
     /// Make POST request with query parameters.
-    pub fn post_with<U, T>(&mut self, params: U, data: &T, query: &Query) -> Result<(), Error>
+    pub async fn post_with<U, T>(&mut self, params: U, data: &T, query: &Query<'_>) -> Result<(), Error>
     where
         T: serde::Serialize + RestPath<U>,
     {
-        self.post_or_put_with(Method::POST, params, data, query)
+        self.post_or_put_with(Method::POST, params, data, query).await
     }
 
     /// Make PUT request with query parameters.
-    pub fn put_with<U, T>(&mut self, params: U, data: &T, query: &Query) -> Result<(), Error>
+    pub async fn put_with<U, T>(&mut self, params: U, data: &T, query: &Query<'_>) -> Result<(), Error>
     where
         T: serde::Serialize + RestPath<U>,
     {
-        self.post_or_put_with(Method::PUT, params, data, query)
+        self.post_or_put_with(Method::PUT, params, data, query).await
     }
 
     /// Make PATCH request with query parameters.
-    pub fn patch_with<U, T>(&mut self, params: U, data: &T, query: &Query) -> Result<(), Error>
+    pub async fn patch_with<U, T>(&mut self, params: U, data: &T, query: &Query<'_>) -> Result<(), Error>
     where
         T: serde::Serialize + RestPath<U>,
     {
-        self.post_or_put_with(Method::PATCH, params, data, query)
+        self.post_or_put_with(Method::PATCH, params, data, query).await
     }
 
-    fn post_or_put_with<U, T>(
+    async fn post_or_put_with<U, T>(
         &mut self,
         method: Method,
         params: U,
         data: &T,
-        query: &Query,
+        query: &Query<'_>,
     ) -> Result<(), Error>
     where
         T: serde::Serialize + RestPath<U>,
@@ -392,29 +392,29 @@ impl RestClient {
         let data = serde_json::to_string(data).map_err(Error::SerializeParseError)?;
 
         let req = self.make_request::<U, T>(method, params, Some(query), Some(data))?;
-        self.run_request(req)?;
+        self.run_request(req).await?;
         Ok(())
     }
 
     /// Make a POST request and capture returned body.
-    pub fn post_capture<U, T, K>(&mut self, params: U, data: &T) -> Result<K, Error>
+    pub async fn post_capture<U, T, K>(&mut self, params: U, data: &T) -> Result<K, Error>
     where
         T: serde::Serialize + RestPath<U>,
         K: serde::de::DeserializeOwned,
     {
-        self.post_or_put_capture(Method::POST, params, data)
+        self.post_or_put_capture(Method::POST, params, data).await
     }
 
     /// Make a PUT request and capture returned body.
-    pub fn put_capture<U, T, K>(&mut self, params: U, data: &T) -> Result<K, Error>
+    pub async fn put_capture<U, T, K>(&mut self, params: U, data: &T) -> Result<K, Error>
     where
         T: serde::Serialize + RestPath<U>,
         K: serde::de::DeserializeOwned,
     {
-        self.post_or_put_capture(Method::PUT, params, data)
+        self.post_or_put_capture(Method::PUT, params, data).await
     }
 
-    fn post_or_put_capture<U, T, K>(
+    async fn post_or_put_capture<U, T, K>(
         &mut self,
         method: Method,
         params: U,
@@ -427,44 +427,44 @@ impl RestClient {
         let data = serde_json::to_string(data).map_err(Error::SerializeParseError)?;
 
         let req = self.make_request::<U, T>(method, params, None, Some(data))?;
-        let body = self.run_request(req)?;
+        let body = self.run_request(req).await?;
         serde_json::from_str(body.as_str()).map_err(|err| Error::DeserializeParseError(err, body))
     }
 
     /// Make a POST request with query parameters and capture returned body.
-    pub fn post_capture_with<U, T, K>(
+    pub async fn post_capture_with<U, T, K>(
         &mut self,
         params: U,
         data: &T,
-        query: &Query,
+        query: &Query<'_>,
     ) -> Result<K, Error>
     where
         T: serde::Serialize + RestPath<U>,
         K: serde::de::DeserializeOwned,
     {
-        self.post_or_put_capture_with(Method::POST, params, data, query)
+        self.post_or_put_capture_with(Method::POST, params, data, query).await
     }
 
     /// Make a PUT request with query parameters and capture returned body.
-    pub fn put_capture_with<U, T, K>(
+    pub async fn put_capture_with<U, T, K>(
         &mut self,
         params: U,
         data: &T,
-        query: &Query,
+        query: &Query<'_>,
     ) -> Result<K, Error>
     where
         T: serde::Serialize + RestPath<U>,
         K: serde::de::DeserializeOwned,
     {
-        self.post_or_put_capture_with(Method::PUT, params, data, query)
+        self.post_or_put_capture_with(Method::PUT, params, data, query).await
     }
 
-    fn post_or_put_capture_with<U, T, K>(
+    async fn post_or_put_capture_with<U, T, K>(
         &mut self,
         method: Method,
         params: U,
         data: &T,
-        query: &Query,
+        query: &Query<'_>,
     ) -> Result<K, Error>
     where
         T: serde::Serialize + RestPath<U>,
@@ -473,32 +473,31 @@ impl RestClient {
         let data = serde_json::to_string(data).map_err(Error::SerializeParseError)?;
 
         let req = self.make_request::<U, T>(method, params, Some(query), Some(data))?;
-        let body = self.run_request(req)?;
+        let body = self.run_request(req).await?;
         serde_json::from_str(body.as_str()).map_err(|err| Error::DeserializeParseError(err, body))
     }
 
     /// Make a DELETE request.
-    pub fn delete<U, T>(&mut self, params: U) -> Result<(), Error>
+    pub async fn delete<U, T>(&mut self, params: U) -> Result<(), Error>
     where
         T: RestPath<U>,
     {
         let req = self.make_request::<U, T>(Method::DELETE, params, None, None)?;
-        self.run_request(req)?;
+        self.run_request(req).await?;
         Ok(())
     }
 
     /// Make a DELETE request with query and body.
-    pub fn delete_with<U, T>(&mut self, params: U, data: &T, query: &Query) -> Result<(), Error>
+    pub async fn delete_with<U, T>(&mut self, params: U, data: &T, query: &Query<'_>) -> Result<(), Error>
     where
         T: serde::Serialize + RestPath<U>,
     {
         let data = serde_json::to_string(data).map_err(Error::SerializeParseError)?;
         let req = self.make_request::<U, T>(Method::DELETE, params, Some(query), Some(data))?;
-        self.run_request(req)?;
+        self.run_request(req).await?;
         Ok(())
     }
 
-    #[tokio::main]
     async fn run_request(&mut self, req: hyper::Request<hyper::Body>) -> Result<String, Error> {
         debug!("{} {}", req.method(), req.uri());
         trace!("{:?}", req);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,9 @@ use std::{error, fmt};
 use std::time::Duration;
 use url::Url;
 
+#[cfg(feature = "blocking")]
+pub mod blocking;
+
 static VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// Type for URL query parameters.
@@ -204,6 +207,13 @@ impl Builder {
     pub fn build(self, url: &str) -> Result<RestClient, Error> {
         RestClient::with_builder(url, self)
     }
+
+    #[cfg(feature = "blocking")]
+    /// Create [`blocking::RestClient`](blocking/struct.RestClient.html) with the configuration in
+    /// this builder
+    pub fn blocking(self, url: &str) -> Result<blocking::RestClient, Error> {
+        RestClient::with_builder(url, self).map(|client| client.into())
+    }
 }
 
 /// Rest path builder trait for type.
@@ -224,6 +234,14 @@ impl RestClient {
     /// Use `Builder` to configure the client.
     pub fn new(url: &str) -> Result<RestClient, Error> {
         RestClient::with_builder(url, RestClient::builder())
+    }
+
+    /// Construct new blocking client with default configuration to make HTTP requests.
+    ///
+    /// Use `Builder` to configure the client.
+    #[cfg(feature = "blocking")]
+    pub fn new_blocking(url: &str) -> Result<blocking::RestClient, Error> {
+        RestClient::new(url).map(|client| client.into())
     }
 
     fn with_builder(url: &str, builder: Builder) -> Result<RestClient, Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,12 +24,13 @@
 //!     fn get_path(_: ()) -> Result<String,Error> { Ok(String::from("anything")) }
 //! }
 //!
-//! fn main() {
+//! #[tokio::main]
+//! async fn main() {
 //!     // Create new client with API base URL
 //!     let mut client = RestClient::new("http://httpbin.org").unwrap();
 //!
 //!     // GET http://httpbin.org/anything and deserialize the result automatically
-//!     let data: HttpBinAnything = client.get(()).unwrap();
+//!     let data: HttpBinAnything = client.get(()).await.unwrap();
 //!     println!("{:?}", data);
 //! }
 //! ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,22 +34,12 @@
 //! }
 //! ```
 
-extern crate futures;
-extern crate hyper;
-extern crate hyper_tls;
-extern crate serde;
-extern crate serde_json;
-extern crate tokio;
-extern crate url;
-#[macro_use]
-extern crate log;
-extern crate base64;
-
 use tokio::time::timeout;
 use hyper::header::*;
 use hyper::body::Buf;
 use hyper::{Client, Method, Request};
 use hyper_tls::HttpsConnector;
+use log::{debug, trace, error};
 use std::{error, fmt};
 use std::time::Duration;
 use url::Url;

--- a/tests/auth.rs
+++ b/tests/auth.rs
@@ -1,9 +1,5 @@
-extern crate restson;
-
-#[macro_use]
-extern crate serde_derive;
-
 use restson::{Error, RestClient, RestPath};
+use serde_derive::Deserialize;
 
 #[derive(Deserialize)]
 struct HttpBinBasicAuth {}

--- a/tests/auth_async.rs
+++ b/tests/auth_async.rs
@@ -11,22 +11,23 @@ impl<'a> RestPath<(&'a str, &'a str)> for HttpBinBasicAuth {
     }
 }
 
-#[test]
-fn basic_auth() {
-    let mut client = RestClient::new_blocking("http://httpbin.org").unwrap();
+#[tokio::test]
+async fn basic_auth() {
+    let mut client = RestClient::new("http://httpbin.org").unwrap();
 
     client.set_auth("username", "passwd");
     client
         .get::<_, HttpBinBasicAuth>(("username", "passwd"))
+        .await
         .unwrap();
 }
 
-#[test]
-fn basic_auth_fail() {
-    let mut client = RestClient::new_blocking("http://httpbin.org").unwrap();
+#[tokio::test]
+async fn basic_auth_fail() {
+    let mut client = RestClient::new("http://httpbin.org").unwrap();
 
     client.set_auth("username", "wrong_passwd");
-    match client.get::<_, HttpBinBasicAuth>(("username", "passwd")) {
+    match client.get::<_, HttpBinBasicAuth>(("username", "passwd")).await {
         Err(Error::HttpError(s, _)) if s == 401 || s == 403 => (),
         _ => panic!("Expected Unauthorized/Forbidden HTTP error"),
     };

--- a/tests/delete.rs
+++ b/tests/delete.rs
@@ -1,9 +1,5 @@
-extern crate restson;
-
-#[macro_use]
-extern crate serde_derive;
-
 use restson::{Error, RestClient, RestPath};
+use serde_derive::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize)]
 struct HttpBinDelete {

--- a/tests/delete_async.rs
+++ b/tests/delete_async.rs
@@ -13,22 +13,22 @@ impl RestPath<()> for HttpBinDelete {
 }
 
 
-#[test]
-fn basic_delete() {
-    let mut client = RestClient::new_blocking("http://httpbin.org").unwrap();
+#[tokio::test]
+async fn basic_delete() {
+    let mut client = RestClient::new("http://httpbin.org").unwrap();
 
-    client.delete::<(), HttpBinDelete>(()).unwrap();
+    client.delete::<(), HttpBinDelete>(()).await.unwrap();
 }
 
-#[test]
-fn delete_with() {
-    let mut client = RestClient::new_blocking("http://httpbin.org").unwrap();
+#[tokio::test]
+async fn delete_with() {
+    let mut client = RestClient::new("http://httpbin.org").unwrap();
 
     let params = vec![("a", "2"), ("b", "abcd")];
     let data = HttpBinDelete {
         data: String::from("test data"),
     };
-    client.delete_with((), &data, &params).unwrap();
+    client.delete_with((), &data, &params).await.unwrap();
 
-    client.delete_with((), &data, &vec![]).unwrap();
+    client.delete_with((), &data, &vec![]).await.unwrap();
 }

--- a/tests/error.rs
+++ b/tests/error.rs
@@ -1,9 +1,5 @@
-extern crate restson;
-
-#[macro_use]
-extern crate serde_derive;
-
 use restson::{Error, RestClient, RestPath};
+use serde_derive::{Deserialize, Serialize};
 use std::time::{Duration, Instant};
 
 #[derive(Serialize, Deserialize)]

--- a/tests/get.rs
+++ b/tests/get.rs
@@ -1,9 +1,5 @@
-extern crate restson;
-
-#[macro_use]
-extern crate serde_derive;
-
 use restson::{Error, RestClient, RestPath};
+use serde_derive::Deserialize;
 use std::time::Duration;
 
 #[derive(Deserialize)]

--- a/tests/get_async.rs
+++ b/tests/get_async.rs
@@ -46,69 +46,69 @@ impl RestPath<()> for HttpRelativePath {
     }
 }
 
-#[test]
-fn basic_get_builder() {
+#[tokio::test]
+async fn basic_get_builder() {
     let mut client = RestClient::builder()
         .timeout(Duration::from_secs(10))
         .send_null_body(false)
-        .blocking("https://httpbin.org")
+        .build("https://httpbin.org")
         .unwrap();
 
-    let data: HttpBinAnything = client.get(()).unwrap();
+    let data: HttpBinAnything = client.get(()).await.unwrap();
     assert_eq!(data.url, "https://httpbin.org/anything");
 }
 
-#[test]
-fn basic_get_https() {
-    let mut client = RestClient::new_blocking("https://httpbin.org").unwrap();
+#[tokio::test]
+async fn basic_get_https() {
+    let mut client = RestClient::new("https://httpbin.org").unwrap();
 
-    let data: HttpBinAnything = client.get(()).unwrap();
+    let data: HttpBinAnything = client.get(()).await.unwrap();
     assert_eq!(data.url, "https://httpbin.org/anything");
 }
 
-#[test]
-fn get_path_param() {
-    let mut client = RestClient::new_blocking("https://httpbin.org").unwrap();
+#[tokio::test]
+async fn get_path_param() {
+    let mut client = RestClient::new("https://httpbin.org").unwrap();
 
-    let data: HttpBinAnything = client.get(1234).unwrap();
+    let data: HttpBinAnything = client.get(1234).await.unwrap();
     assert_eq!(data.url, "https://httpbin.org/anything/1234");
 }
 
-#[test]
-fn get_multi_path_param() {
-    let mut client = RestClient::new_blocking("https://httpbin.org").unwrap();
+#[tokio::test]
+async fn get_multi_path_param() {
+    let mut client = RestClient::new("https://httpbin.org").unwrap();
 
-    let data: HttpBinAnything = client.get((1234, "abcd")).unwrap();
+    let data: HttpBinAnything = client.get((1234, "abcd")).await.unwrap();
     assert_eq!(data.url, "https://httpbin.org/anything/1234/abcd");
 }
 
-#[test]
-fn get_query_params() {
-    let mut client = RestClient::new_blocking("https://httpbin.org").unwrap();
+#[tokio::test]
+async fn get_query_params() {
+    let mut client = RestClient::new("https://httpbin.org").unwrap();
 
     let params = vec![("a", "2"), ("b", "abcd")];
-    let data: HttpBinAnything = client.get_with((), &params).unwrap();
+    let data: HttpBinAnything = client.get_with((), &params).await.unwrap();
 
     assert_eq!(data.url, "https://httpbin.org/anything?a=2&b=abcd");
     assert_eq!(data.args.a, "2");
     assert_eq!(data.args.b, "abcd");
 }
 
-#[test]
-fn relative_path() {
+#[tokio::test]
+async fn relative_path() {
     // When using relative paths, the base path should end with '/'. Otherwise
     // the Url crate join() will replace the last element instead of appending
     // the path returned from get_path().
-    let mut client = RestClient::new_blocking("https://httpbin.org/anything/api/").unwrap();
+    let mut client = RestClient::new("https://httpbin.org/anything/api/").unwrap();
 
-    let data: HttpRelativePath = client.get(()).unwrap();
+    let data: HttpRelativePath = client.get(()).await.unwrap();
     assert_eq!(data.url, "https://httpbin.org/anything/api/test");
 }
 
 
-#[test]
-fn body_wash_fn() {
-    let mut client = RestClient::new_blocking("https://httpbin.org").unwrap();
+#[tokio::test]
+async fn body_wash_fn() {
+    let mut client = RestClient::new("https://httpbin.org").unwrap();
 
     // Ignore the JSON returned by the server and return a static test
     // JSON from the body wash fn so it is easy to detect it was called.
@@ -117,6 +117,6 @@ fn body_wash_fn() {
     };
     client.set_body_wash_fn(body_wash_fn);
 
-    let data: HttpBinAnything = client.get(()).unwrap();
+    let data: HttpBinAnything = client.get(()).await.unwrap();
     assert_eq!(data.url, "from body wash fn");
 }

--- a/tests/headers.rs
+++ b/tests/headers.rs
@@ -1,11 +1,6 @@
-extern crate hyper;
-extern crate restson;
-
-#[macro_use]
-extern crate serde_derive;
-
 use hyper::header::*;
 use restson::{Error, RestClient, RestPath};
+use serde_derive::Deserialize;
 
 #[derive(Deserialize)]
 struct HttpBinAnything {

--- a/tests/headers_async.rs
+++ b/tests/headers_async.rs
@@ -24,48 +24,48 @@ impl RestPath<()> for HttpBinAnything {
     }
 }
 
-#[test]
-fn headers() {
-    let mut client = RestClient::new_blocking("http://httpbin.org").unwrap();
+#[tokio::test]
+async fn headers() {
+    let mut client = RestClient::new("http://httpbin.org").unwrap();
 
     client
         .set_header(USER_AGENT.as_str(), "restson-test")
         .unwrap();
 
-    let data: HttpBinAnything = client.get(()).unwrap();
+    let data: HttpBinAnything = client.get(()).await.unwrap();
     assert_eq!(data.headers.user_agent, "restson-test");
 }
 
-#[test]
-fn headers_clear() {
-    let mut client = RestClient::new_blocking("http://httpbin.org").unwrap();
+#[tokio::test]
+async fn headers_clear() {
+    let mut client = RestClient::new("http://httpbin.org").unwrap();
 
     client.set_header("X-Test", "12345").unwrap();
 
-    let data: HttpBinAnything = client.get(()).unwrap();
+    let data: HttpBinAnything = client.get(()).await.unwrap();
     assert_eq!(data.headers.test, "12345");
 
     client.clear_headers();
 
-    let data: HttpBinAnything = client.get(()).unwrap();
+    let data: HttpBinAnything = client.get(()).await.unwrap();
     assert_eq!(data.headers.test, "");
 }
 
-#[test]
-fn default_user_agent() {
-    let mut client = RestClient::new_blocking("http://httpbin.org").unwrap();
+#[tokio::test]
+async fn default_user_agent() {
+    let mut client = RestClient::new("http://httpbin.org").unwrap();
 
-    let data: HttpBinAnything = client.get(()).unwrap();
+    let data: HttpBinAnything = client.get(()).await.unwrap();
     assert_eq!(
         data.headers.user_agent,
         "restson/".to_owned() + env!("CARGO_PKG_VERSION")
     );
 }
 
-#[test]
-fn response_headers() {
-    let mut client = RestClient::new_blocking("http://httpbin.org").unwrap();
+#[tokio::test]
+async fn response_headers() {
+    let mut client = RestClient::new("http://httpbin.org").unwrap();
 
-    let _data: HttpBinAnything = client.get(()).unwrap();
+    let _data: HttpBinAnything = client.get(()).await.unwrap();
     assert_eq!(client.response_headers()["content-type"], "application/json");
 }

--- a/tests/patch.rs
+++ b/tests/patch.rs
@@ -1,9 +1,5 @@
-extern crate restson;
-
-#[macro_use]
-extern crate serde_derive;
-
 use restson::{Error, RestClient, RestPath};
+use serde_derive::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize)]
 struct HttpBinPatch {

--- a/tests/patch_async.rs
+++ b/tests/patch_async.rs
@@ -12,23 +12,23 @@ impl RestPath<()> for HttpBinPatch {
     }
 }
 
-#[test]
-fn basic_patch() {
-    let mut client = RestClient::new_blocking("http://httpbin.org").unwrap();
+#[tokio::test]
+async fn basic_patch() {
+    let mut client = RestClient::new("http://httpbin.org").unwrap();
 
     let data = HttpBinPatch {
         data: String::from("test data"),
     };
-    client.patch((), &data).unwrap();
+    client.patch((), &data).await.unwrap();
 }
 
-#[test]
-fn patch_query_params() {
-    let mut client = RestClient::new_blocking("http://httpbin.org").unwrap();
+#[tokio::test]
+async fn patch_query_params() {
+    let mut client = RestClient::new("http://httpbin.org").unwrap();
 
     let params = vec![("a", "2"), ("b", "abcd")];
     let data = HttpBinPatch {
         data: String::from("test data"),
     };
-    client.patch_with((), &data, &params).unwrap();
+    client.patch_with((), &data, &params).await.unwrap();
 }

--- a/tests/post.rs
+++ b/tests/post.rs
@@ -1,9 +1,5 @@
-extern crate restson;
-
-#[macro_use]
-extern crate serde_derive;
-
 use restson::{Error, RestClient, RestPath};
+use serde_derive::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize)]
 struct HttpBinPost {

--- a/tests/post_async.rs
+++ b/tests/post_async.rs
@@ -18,49 +18,49 @@ impl RestPath<()> for HttpBinPost {
     }
 }
 
-#[test]
-fn basic_post() {
-    let mut client = RestClient::new_blocking("https://httpbin.org").unwrap();
+#[tokio::test]
+async fn basic_post() {
+    let mut client = RestClient::new("https://httpbin.org").unwrap();
 
     let data = HttpBinPost {
         data: String::from("test data"),
     };
-    client.post((), &data).unwrap();
+    client.post((), &data).await.unwrap();
 }
 
-#[test]
-fn post_query_params() {
-    let mut client = RestClient::new_blocking("https://httpbin.org").unwrap();
+#[tokio::test]
+async fn post_query_params() {
+    let mut client = RestClient::new("https://httpbin.org").unwrap();
 
     let params = vec![("a", "2"), ("b", "abcd")];
     let data = HttpBinPost {
         data: String::from("test data"),
     };
-    client.post_with((), &data, &params).unwrap();
+    client.post_with((), &data, &params).await.unwrap();
 }
 
-#[test]
-fn post_capture() {
-    let mut client = RestClient::new_blocking("https://httpbin.org").unwrap();
+#[tokio::test]
+async fn post_capture() {
+    let mut client = RestClient::new("https://httpbin.org").unwrap();
 
     let data = HttpBinPost {
         data: String::from("test data"),
     };
-    let resp: HttpBinPostResp = client.post_capture((), &data).unwrap();
+    let resp: HttpBinPostResp = client.post_capture((), &data).await.unwrap();
 
     assert_eq!(resp.json.data, "test data");
     assert_eq!(resp.url, "https://httpbin.org/post");
 }
 
-#[test]
-fn post_capture_query_params() {
-    let mut client = RestClient::new_blocking("https://httpbin.org").unwrap();
+#[tokio::test]
+async fn post_capture_query_params() {
+    let mut client = RestClient::new("https://httpbin.org").unwrap();
 
     let params = vec![("a", "2"), ("b", "abcd")];
     let data = HttpBinPost {
         data: String::from("test data"),
     };
-    let resp: HttpBinPostResp = client.post_capture_with((), &data, &params).unwrap();
+    let resp: HttpBinPostResp = client.post_capture_with((), &data, &params).await.unwrap();
 
     assert_eq!(resp.json.data, "test data");
     assert_eq!(resp.url, "https://httpbin.org/post?a=2&b=abcd");

--- a/tests/put.rs
+++ b/tests/put.rs
@@ -1,9 +1,5 @@
-extern crate restson;
-
-#[macro_use]
-extern crate serde_derive;
-
 use restson::{Error, RestClient, RestPath};
+use serde_derive::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize)]
 struct HttpBinPut {

--- a/tests/put_async.rs
+++ b/tests/put_async.rs
@@ -18,49 +18,49 @@ impl RestPath<()> for HttpBinPut {
     }
 }
 
-#[test]
-fn basic_put() {
-    let mut client = RestClient::new_blocking("https://httpbin.org").unwrap();
+#[tokio::test]
+async fn basic_put() {
+    let mut client = RestClient::new("https://httpbin.org").unwrap();
 
     let data = HttpBinPut {
         data: String::from("test data"),
     };
-    client.put((), &data).unwrap();
+    client.put((), &data).await.unwrap();
 }
 
-#[test]
-fn put_query_params() {
-    let mut client = RestClient::new_blocking("https://httpbin.org").unwrap();
+#[tokio::test]
+async fn put_query_params() {
+    let mut client = RestClient::new("https://httpbin.org").unwrap();
 
     let params = vec![("a", "2"), ("b", "abcd")];
     let data = HttpBinPut {
         data: String::from("test data"),
     };
-    client.put_with((), &data, &params).unwrap();
+    client.put_with((), &data, &params).await.unwrap();
 }
 
-#[test]
-fn put_capture() {
-    let mut client = RestClient::new_blocking("https://httpbin.org").unwrap();
+#[tokio::test]
+async fn put_capture() {
+    let mut client = RestClient::new("https://httpbin.org").unwrap();
 
     let data = HttpBinPut {
         data: String::from("test data"),
     };
-    let resp: HttpBinPutResp = client.put_capture((), &data).unwrap();
+    let resp: HttpBinPutResp = client.put_capture((), &data).await.unwrap();
 
     assert_eq!(resp.json.data, "test data");
     assert_eq!(resp.url, "https://httpbin.org/put");
 }
 
-#[test]
-fn put_capture_query_params() {
-    let mut client = RestClient::new_blocking("https://httpbin.org").unwrap();
+#[tokio::test]
+async fn put_capture_query_params() {
+    let mut client = RestClient::new("https://httpbin.org").unwrap();
 
     let params = vec![("a", "2"), ("b", "abcd")];
     let data = HttpBinPut {
         data: String::from("test data"),
     };
-    let resp: HttpBinPutResp = client.put_capture_with((), &data, &params).unwrap();
+    let resp: HttpBinPutResp = client.put_capture_with((), &data, &params).await.unwrap();
 
     assert_eq!(resp.json.data, "test data");
     assert_eq!(resp.url, "https://httpbin.org/put?a=2&b=abcd");


### PR DESCRIPTION
# Motivation

Hyper being an async-native library, you had to start a tokio runtime inside of the library, hidden deep in it. This, however, makes the library unusable in the context of async application that already have a tokio runtime. It could technically be used with heavy use of `tokio::spawn_blocking` to run code outside of the executor, allowing another runtime to be created, avoiding the ineluctable panic tokio produces when starting a runtime inside another runtime, but this solution is clumsy and noisy to use.

# Approach

The approach taken by this PR is the same as the one taken by `reqwest`, which is to make the "primary" client fully async, and have a `blocking` optional module with a sync client, embedding its own tokio runtime. The sync clients merely is a wrapper around the primary async client.

This is a breaking API change, unfortunately, though the migration is rather trivial. Either:
- `RestClient::new` -> `RestClient::new_blocking`
- `Builder::build` -> `Builder::blocking`

As for not doing the opposite (primary client blocking, optional one async), this allows to feature-gate the blocking client, which relies on the `macros` feature of tokio, lightening up dependencies.