### PR TITLE
Parsing by simd json crate in GET requests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,11 @@ edition = "2018"
 hyper = { version = "^0.13.2", default-features = false }
 hyper-tls = "^0.4.1"
 tokio = { version = "^0.2", features = ["time"] }
-serde = "^1.0"
-serde_json = "^1.0"
+#serde = "^1.0"
+#serde_json = "^1.0"
+serde = { version = "^1.0", features = ["derive"], optional = true }
+serde_json = { version = "1.0", optional = true }
+simd-json = { version = "0.1", optional = true }
 url = "2"
 log = "^0.4.6"
 base64 = "0.13"
@@ -25,5 +28,7 @@ serde_derive = "^1.0"
 tokio = { version = "^0.2", features = ["macros"] }
 
 [features]
-default = ["blocking"]
+default = ["blocking", "lib-simd-json"]
 blocking = ["tokio/macros"]
+lib-serde-json = ["serde", "serde_json"]
+lib-simd-json = ["serde", "simd-json", "serde_json"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,6 @@ edition = "2018"
 hyper = { version = "^0.13.2", default-features = false }
 hyper-tls = "^0.4.1"
 tokio = { version = "^0.2", features = ["time"] }
-#serde = "^1.0"
-#serde_json = "^1.0"
 serde = { version = "^1.0", features = ["derive"], optional = true }
 serde_json = { version = "1.0", optional = true }
 simd-json = { version = "0.1", optional = true }
@@ -28,7 +26,7 @@ serde_derive = "^1.0"
 tokio = { version = "^0.2", features = ["macros"] }
 
 [features]
-default = ["blocking", "lib-simd-json"]
+default = ["blocking", "lib-serde-json"]
 blocking = ["tokio/macros"]
 lib-serde-json = ["serde", "serde_json"]
 lib-simd-json = ["serde", "simd-json", "serde_json"]

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -61,22 +61,12 @@ impl RestClient {
     }
 
     /// Make a GET request.
-    #[cfg(feature = "lib-serde-json")]
     #[tokio::main]
     pub async fn get<U, T>(&mut self, params: U) -> Result<T, Error>
     where
         T: serde::de::DeserializeOwned + RestPath<U>,
     {
         self.inner_client.get(params).await
-    }
-
-    #[tokio::main]
-    #[cfg(feature = "lib-simd-json")]
-    pub async fn get_simd<U, T>(&mut self, params: U) -> Result<T, Error>
-    where
-        T: serde::de::DeserializeOwned + RestPath<U>,
-    {
-        self.inner_client.get_simd(params).await
     }
 
     /// Make a GET request with query parameters.

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -61,12 +61,22 @@ impl RestClient {
     }
 
     /// Make a GET request.
+    #[cfg(feature = "lib-serde-json")]
     #[tokio::main]
     pub async fn get<U, T>(&mut self, params: U) -> Result<T, Error>
     where
         T: serde::de::DeserializeOwned + RestPath<U>,
     {
         self.inner_client.get(params).await
+    }
+
+    #[tokio::main]
+    #[cfg(feature = "lib-simd-json")]
+    pub async fn get_simd<U, T>(&mut self, params: U) -> Result<T, Error>
+    where
+        T: serde::de::DeserializeOwned + RestPath<U>,
+    {
+        self.inner_client.get_simd(params).await
     }
 
     /// Make a GET request with query parameters.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -317,7 +317,7 @@ impl RestClient {
         &self.response_headers
     }
 
-    /// Make a GET request with serde json.
+    /// Make a GET request
     pub async fn get<U, T>(&mut self, params: U) -> Result<T, Error>
     where
         T: serde::de::DeserializeOwned + RestPath<U>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -317,7 +317,7 @@ impl RestClient {
         &self.response_headers
     }
 
-    /// Make a GET request
+    /// Make a GET request.
     pub async fn get<U, T>(&mut self, params: U) -> Result<T, Error>
     where
         T: serde::de::DeserializeOwned + RestPath<U>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -353,17 +353,13 @@ impl RestClient {
         #[cfg(feature = "lib-serde-json")]
         {
             let body = self.run_request(req).await?;
-            let _parsed = serde_json::from_str(body.as_str()).map_err(|err| Error::DeserializeParseError(err, body));
-            return _parsed;
+            serde_json::from_str(body.as_str()).map_err(|err| Error::DeserializeParseError(err, body))
         }
         
         #[cfg(feature = "lib-simd-json")]
         {
             let mut body = self.run_request(req).await?;
-
-            let _parsed = simd_json::serde::from_str(&mut body);
-            let result: Result<T, Error> = Ok(_parsed.unwrap());
-            return result;
+            simd_json::serde::from_str(&mut body).map_err(|err| Error::DeserializeParseSimdJsonError(err, body))
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -327,7 +327,8 @@ impl RestClient {
         #[cfg(feature = "lib-serde-json")]
         {
             let body = self.run_request(req).await?;
-            serde_json::from_str(body.as_str()).map_err(|err| Error::DeserializeParseError(err, body))
+            let _parsed = serde_json::from_str(body.as_str()).map_err(|err| Error::DeserializeParseError(err, body));
+            return _parsed;
         }
 
         #[cfg(feature = "lib-simd-json")]
@@ -349,7 +350,8 @@ impl RestClient {
         #[cfg(feature = "lib-serde-json")]
         {
             let body = self.run_request(req).await?;
-            serde_json::from_str(body.as_str()).map_err(|err| Error::DeserializeParseError(err, body))
+            let _parsed = serde_json::from_str(body.as_str()).map_err(|err| Error::DeserializeParseError(err, body));
+            return _parsed;
         }
         
         #[cfg(feature = "lib-simd-json")]
@@ -358,7 +360,7 @@ impl RestClient {
 
             let _parsed = simd_json::serde::from_str(&mut body);
             let result: Result<T, Error> = Ok(_parsed.unwrap());
-            result
+            return result;
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -317,7 +317,21 @@ impl RestClient {
         &self.response_headers
     }
 
-    /// Make a GET request.
+    /// Make a GET request with simd_json library.
+    #[cfg(feature = "lib-simd-json")]
+    pub async fn get_simd<U, T>(&mut self, params: U) -> Result<T, Error>
+    where
+        T: serde::de::DeserializeOwned + RestPath<U>,
+    {
+        let req = self.make_request::<U, T>(Method::GET, params, None, None)?;
+        let mut body = self.run_request(req).await?;
+        let _parsed = simd_json::serde::from_str(&mut body);
+        let result: Result<T, Error> = Ok(_parsed.unwrap());
+        result
+    }
+
+    /// Make a GET request with serde json.
+    #[cfg(feature = "lib-serde-json")]
     pub async fn get<U, T>(&mut self, params: U) -> Result<T, Error>
     where
         T: serde::de::DeserializeOwned + RestPath<U>,


### PR DESCRIPTION
Issue #28
simd_json parsing was added as `lib-simd-json` configuration. Default configuration is `lib-serde-json`.
Serializing is still by serde_json, because the speed of serializing will be approximately the same.
The only problem I see in simd_json::Error. This error should be converted to Error type. Probably somebody can tell me how to do it.