### PR TITLE
Use a shared tokio runtime for a blocking rest client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["rest", "client", "http", "json", "async"]
 categories = ["network-programming", "web-programming::http-client"]
 readme = "README.md"
 license = "MIT"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 hyper = { version = "0.14", features = ["client", "http1", "http2"] }
@@ -28,6 +28,6 @@ tokio = { version = "1", features = ["macros"] }
 
 [features]
 default = ["blocking", "lib-serde-json"]
-blocking = ["tokio/macros"]
+blocking = []
 lib-serde-json = ["serde", "serde_json"]
 lib-simd-json = ["serde", "simd-json", "serde_json"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -277,7 +277,7 @@ impl Builder {
     /// Create [`blocking::RestClient`](blocking/struct.RestClient.html) with the configuration in
     /// this builder
     pub fn blocking(self, url: &str) -> Result<blocking::RestClient, Error> {
-        RestClient::with_builder(url, self).map(|client| client.into())
+        RestClient::with_builder(url, self).and_then(|client| client.try_into())
     }
 }
 
@@ -306,7 +306,7 @@ impl RestClient {
     /// Use `Builder` to configure the client.
     #[cfg(feature = "blocking")]
     pub fn new_blocking(url: &str) -> Result<blocking::RestClient, Error> {
-        RestClient::new(url).map(|client| client.into())
+        RestClient::new(url).and_then(|client| client.try_into())
     }
 
     fn with_builder(url: &str, builder: Builder) -> Result<RestClient, Error> {


### PR DESCRIPTION
This avoids creating a whole new runtime for each request being made, which avoids duplicating IO and time drivers (threads being spawned).

As per the tokio docs, a `current_thread` runtime can be used from multiple concurrent threads, so this is still thread safe.