### PR TITLE
Add more context to errors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,8 +197,13 @@ impl fmt::Display for Error {
         };
         fmt.write_str(desc)?;
         match *self {
-            Error::SerializeParseError(ref err) => write!(fmt, ": {}", err),
-            Error::DeserializeParseError(ref err, _) => write!(fmt, ": {}", err),
+            Error::SerializeParseError(ref err) => write!(fmt, ": {err}"),
+            Error::DeserializeParseError(ref err, _) => write!(fmt, ": {err}"),
+            #[cfg(feature = "lib-simd-json")]
+            Error::DeserializeParseSimdJsonError(ref err, _) => write!(fmt, ": {err}"),
+            Error::HyperError(ref err) => write!(fmt, ": {err}"),
+            Error::IoError(ref err) => write!(fmt, ": {err}"),
+            Error::HttpError(status, ref body) => write!(fmt, ": HTTP status {status}: {body}"),
             _ => Ok(()),
         }
     }
@@ -209,6 +214,9 @@ impl error::Error for Error {
         match *self {
             Error::SerializeParseError(ref err) => Some(err),
             Error::DeserializeParseError(ref err, _) => Some(err),
+            Error::HyperError(ref err) => Some(err),
+            #[cfg(feature = "lib-simd-json")]
+            Error::DeserializeParseSimdJsonError(ref err, _) => Some(err),
             _ => None,
         }
     }


### PR DESCRIPTION
This is especially useful for API errors and help give an useful error message by including the body in the displayed error.

For example, when using the Netbox API with a non existing tag, and passing errors to anyhow, we go from:

```
2022-08-22T13:25:59.325686Z ERROR app: Failed my-server: Server returned non-success status
```

to the much nicer

```
2022-08-22T13:26:23.486371Z ERROR app: Failed my-server: Server returned non-success status: HTTP status 400: {"tag":["Select a valid choice. rust is not one of the available choices."]}
```